### PR TITLE
Align Swipe APIs with Matchmaking Service

### DIFF
--- a/src/hooks/useRecommendations.ts
+++ b/src/hooks/useRecommendations.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { Profile } from '../types/profile';
 import { authorizedRequest } from '../services/api.service';
+import { swipeLeft, swipeRight } from '../services/matchmaking.service';
 import { mapRecommendationToProfile, type RecommendationUser } from '../utils/profile.mapper';
 
 interface RecommendationsResponse {
@@ -8,15 +9,6 @@ interface RecommendationsResponse {
   message: string;
   count: number;
   users?: RecommendationUser[];
-}
-
-interface ApiResponse {
-  success: boolean;
-  message: string;
-}
-
-interface RightSwipeResponse extends ApiResponse {
-  connected?: boolean;
 }
 
 interface UseRecommendationsOptions {
@@ -68,6 +60,26 @@ export const useRecommendations = ({
     (direction: 'left' | 'right', swipedProfile: Profile) => {
       setSwipeError(null);
 
+      if (direction === 'left') {
+        // Left swipes are recorded server-side but are not treated as dismissals in swipe lists.
+        setProfiles((previousProfiles) => {
+          if (previousProfiles.length === 0) {
+            return previousProfiles;
+          }
+
+          if (previousProfiles[0].id === swipedProfile.id) {
+            return previousProfiles.slice(1);
+          }
+
+          return previousProfiles.filter((profile) => profile.id !== swipedProfile.id);
+        });
+
+        void swipeLeft(swipedProfile.id, { token, firebaseToken }).catch((error) => {
+          setSwipeError(error instanceof Error ? error.message : 'Failed to record left swipe');
+        });
+        return;
+      }
+
       setProfiles((previousProfiles) => {
         if (previousProfiles.length === 0) {
           return previousProfiles;
@@ -80,22 +92,7 @@ export const useRecommendations = ({
         return previousProfiles.filter((profile) => profile.id !== swipedProfile.id);
       });
 
-      if (direction === 'left') {
-        void authorizedRequest<ApiResponse>('/api/leftswipe', {
-          method: 'POST',
-          auth: { token, firebaseToken },
-          body: JSON.stringify({ targetUserId: swipedProfile.id }),
-        }).catch((error) => {
-          setSwipeError(error instanceof Error ? error.message : 'Failed to record left swipe');
-        });
-        return;
-      }
-
-      void authorizedRequest<RightSwipeResponse>('/api/swipe/right', {
-        method: 'POST',
-        auth: { token, firebaseToken },
-        body: JSON.stringify({ toUserId: swipedProfile.id }),
-      }).catch((error) => {
+      void swipeRight(swipedProfile.id, { token, firebaseToken }).catch((error) => {
         setSwipeError(error instanceof Error ? error.message : 'Failed to record right swipe');
       });
     },

--- a/src/services/matchmaking.service.ts
+++ b/src/services/matchmaking.service.ts
@@ -1,0 +1,127 @@
+import { authorizedRequest, type AuthTokenSources } from './api.service';
+import type {
+  MatchRequestAction,
+  MatchRequestRecord,
+  MatchRequestsResponse,
+  SwipeListUserCollections,
+  SwipeListsResponse,
+} from '../types/matchmaking';
+import type { RecommendationUser } from '../utils/profile.mapper';
+
+interface ApiResponse {
+  success: boolean;
+  message?: string;
+}
+
+export interface SwipeRightResponse extends ApiResponse {
+  connected?: boolean;
+}
+
+interface SwipeListsOptions {
+  includeProfiles?: boolean;
+  signal?: AbortSignal;
+}
+
+const EMPTY_SWIPE_LISTS: SwipeListUserCollections = {
+  leftswiped: [],
+  swipedRight: [],
+  gotSwipedRight: [],
+  matchRequestsSent: [],
+  matchRequestsReceived: [],
+  connected: [],
+  acceptedMatches: [],
+  rejectedMatches: [],
+};
+
+const getRecommendationUsers = (value: unknown): RecommendationUser[] =>
+  Array.isArray(value) ? (value as RecommendationUser[]) : [];
+
+const getMatchRequestRecords = (value: unknown): MatchRequestRecord[] =>
+  Array.isArray(value) ? (value as MatchRequestRecord[]) : [];
+
+export const swipeRight = async (
+  toUserId: string,
+  auth: AuthTokenSources
+): Promise<SwipeRightResponse> =>
+  authorizedRequest<SwipeRightResponse>('/api/swipe/right', {
+    method: 'POST',
+    auth,
+    body: JSON.stringify({ toUserId }),
+  });
+
+export const swipeLeft = async (toUserId: string, auth: AuthTokenSources): Promise<ApiResponse> =>
+  authorizedRequest<ApiResponse>('/api/swipe/left', {
+    method: 'POST',
+    auth,
+    body: JSON.stringify({ toUserId }),
+  });
+
+export const respondToMatchRequest = async (
+  fromUserId: string,
+  action: MatchRequestAction,
+  auth: AuthTokenSources
+): Promise<ApiResponse> =>
+  authorizedRequest<ApiResponse>(`/api/match-requests/${fromUserId}/respond`, {
+    method: 'POST',
+    auth,
+    body: JSON.stringify({ action }),
+  });
+
+export const getMyMatchRequests = async (
+  auth: AuthTokenSources,
+  signal?: AbortSignal
+) => {
+  const response = await authorizedRequest<MatchRequestsResponse>('/api/match-requests/me', {
+    method: 'GET',
+    auth,
+    signal,
+  });
+
+  const data = response.data ?? {};
+
+  return {
+    incoming: getMatchRequestRecords(response.incoming ?? data.incoming),
+    outgoing: getMatchRequestRecords(response.outgoing ?? data.outgoing),
+    accepted: getMatchRequestRecords(response.accepted ?? data.accepted),
+    rejected: getMatchRequestRecords(response.rejected ?? data.rejected),
+  };
+};
+
+export const getMySwipeLists = async (
+  auth: AuthTokenSources,
+  options: SwipeListsOptions = {}
+): Promise<SwipeListUserCollections> => {
+  const searchParams = new URLSearchParams();
+
+  if (typeof options.includeProfiles === 'boolean') {
+    searchParams.set('includeProfiles', String(options.includeProfiles));
+  }
+
+  const queryString = searchParams.toString();
+  const response = await authorizedRequest<SwipeListsResponse>(
+    `/api/swipe/lists/me${queryString ? `?${queryString}` : ''}`,
+    {
+      method: 'GET',
+      auth,
+      signal: options.signal,
+    }
+  );
+
+  const data = response.data ?? {};
+
+  return {
+    ...EMPTY_SWIPE_LISTS,
+    leftswiped: getRecommendationUsers(response.leftswiped ?? data.leftswiped),
+    swipedRight: getRecommendationUsers(response.swipedRight ?? data.swipedRight),
+    gotSwipedRight: getRecommendationUsers(response.gotSwipedRight ?? data.gotSwipedRight),
+    matchRequestsSent: getRecommendationUsers(
+      response.matchRequestsSent ?? data.matchRequestsSent
+    ),
+    matchRequestsReceived: getRecommendationUsers(
+      response.matchRequestsReceived ?? data.matchRequestsReceived
+    ),
+    connected: getRecommendationUsers(response.connected ?? data.connected),
+    acceptedMatches: getRecommendationUsers(response.acceptedMatches ?? data.acceptedMatches),
+    rejectedMatches: getRecommendationUsers(response.rejectedMatches ?? data.rejectedMatches),
+  };
+};

--- a/src/types/matchmaking.ts
+++ b/src/types/matchmaking.ts
@@ -1,0 +1,72 @@
+import type { RecommendationUser } from '../utils/profile.mapper';
+
+export type MatchRequestAction = 'accept' | 'reject';
+
+export interface MatchRequestUser {
+  uid?: string;
+  _id?: string;
+  id?: string;
+  fullName?: string;
+  age?: number;
+  role?: string;
+  location?: string;
+  city?: string;
+  country?: string;
+  aboutMe?: string;
+  profileImage?: string;
+  githubProfileUrl?: string;
+  interests?: string[];
+  goal?: string;
+}
+
+export interface MatchRequestRecord {
+  id?: string;
+  _id?: string;
+  fromUserId?: string;
+  toUserId?: string;
+  fromUser?: MatchRequestUser | RecommendationUser;
+  toUser?: MatchRequestUser | RecommendationUser;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface MatchRequestsResponse {
+  success: boolean;
+  message?: string;
+  incoming?: MatchRequestRecord[];
+  outgoing?: MatchRequestRecord[];
+  accepted?: MatchRequestRecord[];
+  rejected?: MatchRequestRecord[];
+  data?: {
+    incoming?: MatchRequestRecord[];
+    outgoing?: MatchRequestRecord[];
+    accepted?: MatchRequestRecord[];
+    rejected?: MatchRequestRecord[];
+  };
+}
+
+export interface SwipeListUserCollections {
+  leftswiped: RecommendationUser[];
+  swipedRight: RecommendationUser[];
+  gotSwipedRight: RecommendationUser[];
+  matchRequestsSent: RecommendationUser[];
+  matchRequestsReceived: RecommendationUser[];
+  connected: RecommendationUser[];
+  acceptedMatches: RecommendationUser[];
+  rejectedMatches: RecommendationUser[];
+}
+
+export interface SwipeListsResponse {
+  success: boolean;
+  message?: string;
+  leftswiped?: RecommendationUser[];
+  swipedRight?: RecommendationUser[];
+  gotSwipedRight?: RecommendationUser[];
+  matchRequestsSent?: RecommendationUser[];
+  matchRequestsReceived?: RecommendationUser[];
+  connected?: RecommendationUser[];
+  acceptedMatches?: RecommendationUser[];
+  rejectedMatches?: RecommendationUser[];
+  data?: Partial<SwipeListUserCollections>;
+}


### PR DESCRIPTION
## Summary
This PR updates the swipe flow to align with the current backend matchmaking API and introduces a reusable, typed service layer for all matchmaking-related operations.

## API Updates
### POST `/api/swipe/left`
- Replaces legacy `POST /api/leftswipe`
- New request body: `{ "toUserId": "<string>" }`
- Aligns with the structure used by the right swipe endpoint

### POST `/api/swipe/right`
* No contract changes
* Now routed through the shared matchmaking service

## Matchmaking Service Layer
Introduced a reusable client in `matchmaking.service.ts` with shared types defined in `matchmaking.ts`.

### Supported endpoints:
* `POST /api/swipe/right`
* `POST /api/swipe/left`
* `POST /api/match-requests/:fromUserId/respond`
* `GET /api/match-requests/me`
* `GET /api/swipe/lists/me?includeProfiles=true`

This creates a single source of truth for matchmaking-related API interactions.

## Hook Update
### `useRecommendations.ts`
* Routes both swipe directions through the matchmaking service
* Updates left swipe:
  * Old: `/api/leftswipe` with `targetUserId`
  * New: `/api/swipe/left` with `{ toUserId }`
* Keeps right swipe aligned with `/api/swipe/right`
* Ensures compatibility with Dashboard and SwipeCard components

### Verification
* `npm run build` completes successfully
* Swipe interactions tested with updated endpoints
* No regressions observed in recommendation loading or UI states

